### PR TITLE
Support milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,8 @@
 - Configuring the global default through the FastAPILimiter.init method.
 - Update status to 429 when too many requests.
 - Update default_callback params and add `Retry-After` response header.
+
+### 0.1.2
+
+- Use milliseconds instead of seconds as default unit of expiration.
+- Update default_callback, round milliseconds up to nearest second for `Retry-After` value.

--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 import aioredis
+from math import ceil
 from fastapi import HTTPException
 from starlette.requests import Request
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
@@ -13,13 +14,16 @@ async def default_identifier(request: Request):
     return request.client.host
 
 
-async def default_callback(request: Request, expire: int):
+async def default_callback(request: Request, pexpire: int):
     """
     default callback when too many requests
     :param request:
-    :param expire: The remaining seconds
+    :param pexpire: The remaining milliseconds
     :return:
     """
+    
+    expire = ceil(pexpire / 1000)
+
     raise HTTPException(
         HTTP_429_TOO_MANY_REQUESTS, "Too Many Requests", headers={"Retry-After": str(expire)}
     )

--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -21,7 +21,6 @@ async def default_callback(request: Request, pexpire: int):
     :param pexpire: The remaining milliseconds
     :return:
     """
-    
     expire = ceil(pexpire / 1000)
 
     raise HTTPException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/long2ice/fastapi-limiter.git"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 aioredis = "*"


### PR DESCRIPTION
Thanks for the great contribution to FastApi!

I was thinking it'd be a good idea to support milliseconds so that: 

1. fractions of seconds can be used, and
2. it's the unit expiring information is stored https://redis.io/commands/expire#expires-and-persistence

My first take is that milliseconds should be used as the default for all rate limiting but to avoid breaking changes I'd be happy to add a flag for seconds vs. milliseconds. Please let me know what you think!

