### PR TITLE
Access response in callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 
 - Use milliseconds instead of seconds as default unit of expiration.
 - Update default_callback, round milliseconds up to nearest second for `Retry-After` value.
+- Access response in callback.

--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -4,6 +4,7 @@ import aioredis
 from math import ceil
 from fastapi import HTTPException
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 
 
@@ -14,7 +15,7 @@ async def default_identifier(request: Request):
     return request.client.host
 
 
-async def default_callback(request: Request, pexpire: int):
+async def default_callback(request: Request, response: Response, pexpire: int):
     """
     default callback when too many requests
     :param request:

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -39,4 +39,4 @@ class RateLimiter:
         if num == 1:
             await redis.pexpire(key, self.milliseconds)
         if num > self.times:
-            return await callback(request, pexpire)
+            return await callback(request, response, pexpire)


### PR DESCRIPTION
In some cases I'd like direct access to the response as well as the request in the callback.

e.g. https://fastapi.tiangolo.com/advanced/response-change-status-code/