### PR TITLE
Allow Rate Limiting within WebSockets

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -35,13 +35,13 @@ async def multiple():
     return {"msg": "Hello World"}
 
 @app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket, ratelimit=Depends()):
+async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     ratelimit = WebSocketRateLimiter(times=1, seconds=5)
     while True:
         try: 
             data = await websocket.receive_text()
-            await ratelimit(websocket, context_key=data)
+            await ratelimit(websocket, context_key=data) # NB: context_key is optional
             await websocket.send_text(f"Hello, world")
         except WebSocketRateLimitException:
             await websocket.send_text(f"Hello again")

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,9 +1,9 @@
 import redis.asyncio as redis
 import uvicorn
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, WebSocket
 
 from fastapi_limiter import FastAPILimiter
-from fastapi_limiter.depends import RateLimiter
+from fastapi_limiter.depends import RateLimiter, WebSocketRateLimiter
 
 app = FastAPI()
 
@@ -34,6 +34,17 @@ async def index():
 async def multiple():
     return {"msg": "Hello World"}
 
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    ratelimit = WebSocketRateLimiter(times=1, seconds=5)
+    while True:
+        limited = await ratelimit()
+        data = await websocket.receive_text()
+        if limited: 
+            await websocket.send_text(f"Hello again")
+        else:
+            await websocket.send_text(f"Hello, world")
 
 if __name__ == "__main__":
     uvicorn.run("main:app", debug=True, reload=True)

--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -9,7 +9,8 @@ from starlette.websockets import WebSocket
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 from typing import Union
 
-
+class WebSocketRateLimitException(Exception):
+    pass
 
 async def default_identifier(request: Union[Request, WebSocket]):
     forwarded = request.headers.get("X-Forwarded-For")

--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -5,10 +5,13 @@ import redis.asyncio as redis
 from fastapi import HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.websockets import WebSocket
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+from typing import Union
 
 
-async def default_identifier(request: Request):
+
+async def default_identifier(request: Union[Request, WebSocket]):
     forwarded = request.headers.get("X-Forwarded-For")
     if forwarded:
         ip = forwarded.split(",")[0]

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -55,6 +55,8 @@ class RateLimiter:
 
 class WebSocketRateLimiter(RateLimiter):
     async def __call__(self, ws: WebSocket, context_key=""):
+        if not FastAPILimiter.redis:
+            raise Exception("You must call FastAPILimiter.init in startup event of fastapi!")
         identifier = self.identifier or FastAPILimiter.identifier
         rate_key = await identifier(ws)
         key = f"{FastAPILimiter.prefix}:ws:{rate_key}:{context_key}"

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 from pydantic import conint
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.websockets import WebSocket
 
 from fastapi_limiter import FastAPILimiter
 
@@ -23,6 +24,14 @@ class RateLimiter:
         self.identifier = identifier
         self.callback = callback
 
+    async def _check(self, key):
+        redis = FastAPILimiter.redis
+        pexpire = await redis.evalsha(
+            FastAPILimiter.lua_sha, 1, key, str(self.times), str(self.milliseconds)
+        )
+        return pexpire
+
+
     async def __call__(self, request: Request, response: Response):
         if not FastAPILimiter.redis:
             raise Exception("You must call FastAPILimiter.init in startup event of fastapi!")
@@ -33,18 +42,26 @@ class RateLimiter:
                     if self is dependency.dependency:
                         index = idx
                         break
+
         # moved here because constructor run before app startup
         identifier = self.identifier or FastAPILimiter.identifier
         callback = self.callback or FastAPILimiter.callback
-        redis = FastAPILimiter.redis
         rate_key = await identifier(request)
         key = f"{FastAPILimiter.prefix}:{rate_key}:{index}"
-        pexpire = await redis.evalsha(
-            FastAPILimiter.lua_sha, 1, key, str(self.times), str(self.milliseconds)
-        )
+        pexpire = await self._check(key)
         if pexpire != 0:
             return await callback(request, response, pexpire)
 
+
+class WebSocketRateLimitException(Exception):
+    pass
+
 class WebSocketRateLimiter(RateLimiter):
-        async def __call__(self):
-            pass
+    async def __call__(self, ws: WebSocket, context_key=""):
+        identifier = self.identifier or FastAPILimiter.identifier
+        rate_key = await identifier(ws)
+        key = f"{FastAPILimiter.prefix}:ws:{rate_key}:{context_key}"
+        pexpire = await self._check(key)
+        if pexpire != 0:
+            raise WebSocketRateLimitException() 
+

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -44,3 +44,7 @@ class RateLimiter:
         )
         if pexpire != 0:
             return await callback(request, response, pexpire)
+
+class WebSocketRateLimiter(RateLimiter):
+        async def __call__(self):
+            pass

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.websockets import WebSocket
 
-from fastapi_limiter import FastAPILimiter
+from fastapi_limiter import FastAPILimiter, WebSocketRateLimitException
 
 
 class RateLimiter:
@@ -52,9 +52,6 @@ class RateLimiter:
         if pexpire != 0:
             return await callback(request, response, pexpire)
 
-
-class WebSocketRateLimitException(Exception):
-    pass
 
 class WebSocketRateLimiter(RateLimiter):
     async def __call__(self, ws: WebSocket, context_key=""):

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -46,7 +46,11 @@ def test_limiter_websockets():
             data = ws.receive_text()
             assert data == "Hello, world"
 
-            ws.send_text("Hi 2")
+            ws.send_text("Hi")
+            data = ws.receive_text()
             assert data == "Hello again"
 
+            ws.send_text("Hi 2")
+            data = ws.receive_text()
+            assert data == "Hello, world"
             ws.close()

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -38,3 +38,15 @@ def test_limiter_multiple():
 
         response = client.get("/multiple")
         assert response.status_code == 200
+
+def test_limiter_websockets():
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws") as ws:
+            ws.send_text("Hi")
+            data = ws.receive_text()
+            assert data == "Hello, world"
+
+            ws.send_text("Hi 2")
+            assert data == "Hello again"
+
+            ws.close()


### PR DESCRIPTION
This PR adds the capability to do rate limiting within websocket requests.

For example (see examples/main.py):

```python
@app.websocket("/ws")
async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     ratelimit = WebSocketRateLimiter(times=1, seconds=5)
     while True:
         try:
             data = await websocket.receive_text()
             await ratelimit(websocket, context_key=data) # NB: context_key is optional
             await websocket.send_text(f"Hello, world")
         except WebSocketRateLimitException:
             await websocket.send_text(f"Hello again")
```

---

#### Context

I was attempting to rate limit graphql requests. As graphql requests can come over a request or over a websocket, the conventional method of dependencies doesn't work. But the majority of the things we need to rate limit are already there - we have FastAPI with a redis client. All we have to do is construct the redis cache key a little differently.

In order to support multiple rate strategies for a single route, currently in depends.py we iterate through the dependencies of the current route and store the index of the dependency which is then used in the rate limiting key. (See https://github.com/peterbraden/fastapi-limiter/commit/dd385d624c8d1000d9f3d2b335186cb6f638f1ab)

In https://github.com/peterbraden/fastapi-limiter/blob/4e6c6fa6d8339bad459d801814c61735b658ae25/fastapi_limiter/depends.py#L32 the code assumes that the route has a dependencies list.

In fact dependencies is [optional in APIRoute](https://github.com/tiangolo/fastapi/blob/master/fastapi/routing.py#L321) and doesn't appear at all in [APIWebSocketRoute](https://github.com/tiangolo/fastapi/blob/master/fastapi/routing.py#L284).

In a websocket none of this makes sense, we likely want to ratelimit more often than the lifetime of the websocket connection, and additionally we don't have connection scoped dependencies.

Instead of trying to shoehorn this into the existing method, I've simply added a class WebSocketRateLimiter that derives from RateLimiter, and can be called directly within a websocket connection.




