### PR TITLE
update redis requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ packages = [
 ]
 readme = "README.md"
 repository = "https://github.com/long2ice/fastapi-limiter.git"
-version = "0.1.5"
+version = "0.1.6"
 
 [tool.poetry.dependencies]
-redis = "^4.2.0rc1"
+redis = ">=4.2.0rc1"
 fastapi = "*"
 python = "^3.7"
 


### PR DESCRIPTION
By poetry [dependency specification](https://python-poetry.org/docs/dependency-specification#dependency-specification), this will support redis 5.0.