### PR TITLE
fix: when unset time limit

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -40,6 +40,11 @@ async def multiple():
     return {"msg": "Hello World"}
 
 
+@app.get("/unlimited", dependencies=[Depends(RateLimiter())])
+async def unlimited():
+    return {"msg": "Hello World"}
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()

--- a/fastapi_limiter/depends.py
+++ b/fastapi_limiter/depends.py
@@ -26,6 +26,8 @@ class RateLimiter:
         self.callback = callback
 
     async def _check(self, key):
+        if self.milliseconds <= 0:
+            return 0
         redis = FastAPILimiter.redis
         pexpire = await redis.evalsha(
             FastAPILimiter.lua_sha, 1, key, str(self.times), str(self.milliseconds)

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -65,3 +65,12 @@ def test_limiter_websockets():
             data = ws.receive_text()
             assert data == "Hello, world"
             ws.close()
+
+
+def test_unlimited():
+    with TestClient(app) as client:
+        response = client.get("/unlimited")
+        assert response.status_code == 200
+
+        response = client.get("/unlimited")
+        assert response.status_code == 200


### PR DESCRIPTION
The `RateLimiter` class was designed to allow time constraints to be null and default to 0. It can be assumed that if the user does not pass any time constraints, there are no limits.

However, when `0` is passed into the Redis script:
`redis.call("SET", key, 1, "px", "0")`

It triggers an exception:

`redis.exceptions.ResponseError: invalid expire time in 'set' command script`

Hence, this PR is proposed.