### PR TITLE
(fix) redis call to .close() was depricated in 5.0.1

### DIFF
--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -86,4 +86,4 @@ end"""
 
     @classmethod
     async def close(cls) -> None:
-        await cls.redis.close()
+        await cls.redis.aclose()


### PR DESCRIPTION
updated close method to use the redis.aclose() method