### PR TITLE
Add circuitbreaker pattern to the rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ async def multiple():
 
 Not that you should note the dependencies orders, keep lower of result of `seconds/times` at the first.
 
+## Circuit breaker
+In order to avoid errors when redis is unavailable, you can apply a circuitbreaker to a RateLimiter instance. The `circuitbreaker` parameter accepts a tuple of `(max_failures, recovery_timeout)` and if enabled, after reaching the maximum amount of failures, the rate limiting will be disabled and redis usage will be tried again only after the timeout.
+
+```py
+@app.get(
+    "/circuit-breaker", 
+    dependencies=[Depends(RateLimiter(times=1, seconds=5, circuit_breaker=(2, 5)))])
+async def circuit_breaker():
+    return {"msg": "Hello World"}
+# This example will stop ratelimiting on the second connection error,
+# and retry after 5 seconds.
+```
+
 ## Rate limiting within a websocket.
 
 While the above examples work with rest requests, FastAPI also allows easy usage

--- a/examples/main.py
+++ b/examples/main.py
@@ -40,6 +40,14 @@ async def multiple():
     return {"msg": "Hello World"}
 
 
+@app.get(
+    "/circuit-breaker",
+    dependencies=[Depends(RateLimiter(times=1, seconds=5, circuit_breaker=(2, 5)))],
+)
+async def circuit_breaker():
+    return {"msg": "Hello World"}
+
+
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -1,6 +1,8 @@
 from time import sleep
+from unittest.mock import patch
 
 from starlette.testclient import TestClient
+import redis
 
 from examples.main import app
 
@@ -48,6 +50,41 @@ def test_limiter_multiple():
 
         response = client.get("/multiple")
         assert response.status_code == 200
+
+
+def test_limiter_circuit_breaker():
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 200
+
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 429
+
+        with patch("fastapi_limiter.FastAPILimiter.redis.evalsha", autospec=True) as mock_evalsha:
+            mock_evalsha.side_effect = redis.exceptions.ConnectionError
+            response = client.get("/circuit-breaker")
+            assert response.status_code == 500
+
+            # Circuit breaker triggered, rate limiting disabled
+
+            response = client.get("/circuit-breaker")
+            assert response.status_code == 200
+
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 200
+
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 200
+
+        sleep(5)
+
+        # retry after circuit breaker timeout
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 200
+
+        response = client.get("/circuit-breaker")
+        assert response.status_code == 429
+
 
 
 def test_limiter_websockets():


### PR DESCRIPTION
Added an option to apply a circuit breaker to the rate limiter, in order to better handle temporary unavailability of Redis (as raised in #54 )

```py
@app.get(
    "/circuit-breaker", 
    dependencies=[Depends(RateLimiter(times=1, seconds=5, circuit_breaker=(2, 5)))])
async def circuit_breaker():
    return {"msg": "Hello World"}
# This example will stop ratelimiting on the second connection error,
# and retry after 5 seconds.
```