### PR TITLE
Use `aclose()` instead of `close()` to close redis client

### DIFF
--- a/fastapi_limiter/__init__.py
+++ b/fastapi_limiter/__init__.py
@@ -86,4 +86,4 @@ end"""
 
     @classmethod
     async def close(cls) -> None:
-        await cls.redis.close()
+        await cls.redis.aclose()


### PR DESCRIPTION
`close()` method of redis is deprecated since version 5.0.1.